### PR TITLE
Automate release notes

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,60 @@
+name: Release Notes
+
+on:
+  push:
+    branches: [ main, release* ]
+  pull_request:
+    branches: [ main, release* ]
+
+jobs:
+  generate-release-notes:
+    name: Generate Release Notes
+    runs-on: macos-13
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Required for Calculate Version step (e.g. GitVersion)
+
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.10.2
+        with:
+          versionSpec: '5.12.0'
+
+      - name: GitVersion Config
+        uses: gittools/actions/gitversion/execute@v0.10.2
+        with:
+          useConfigFile: true
+          additionalArguments: '/showConfig'
+
+      - name: Determine Version
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v0.10.2
+        with:
+          useConfigFile: true
+          additionalArguments: '/updateprojectfiles'
+
+      - name: Install GitReleaseManager
+        uses: gittools/actions/gitreleasemanager/setup@v0.10.2
+        with:
+          versionSpec: '0.13.0'
+
+      # If there are no closed issues generating the Github Release will fail because it raises an exception.
+      # Work around this by checking for success or no closed issue errors.
+      - name: Create Release ${{ steps.gitversion.outputs.majorMinorPatch }}
+        run: |
+          dotnet gitreleasemanager create --owner saturdaymp --repository BEMCheckBox --token ${{ secrets.GITHUB_TOKEN }} --milestone v${{ steps.gitversion.outputs.majorMinorPatch }} --logFilePath output.txt || true
+          cat output.txt | grep 'No closed issues have been found for milestone\|Drafted release is available at'
+
+      - name: 'Generate Change Log'
+        run: |
+          dotnet-gitreleasemanager export --token ${{ secrets.GITHUB_TOKEN }} -o 'saturdaymp' -r 'BEMCheckBox' -f 'CHANGELOG.md'
+          git add --renormalize CHANGELOG.md
+          cat CHANGELOG.md
+
+      - name: 'Commit Change Log if it Changed'
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Committing auto generated change log.
+          file_pattern: CHANGELOG.md

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -17,6 +17,12 @@ jobs:
         with:
           fetch-depth: 0 # Required for Calculate Version step (e.g. GitVersion)
 
+      # Required by GitVersion
+      - name: Install .NET 6.0
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0
+
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.10.2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
-# Change Log
+## v2.0.0 (Aug, 3, 2023)
 
-## [v1.1.0](https://github.com/Boris-Em/BEMCheckBox/tree/1.1.0) (2015-10-17)
-[Full Changelog](https://github.com/Boris-Em/BEMCheckBox/compare/1.0.0...1.1.0)
-  
-Added new delegate and BEMCheckBoxDelegate protocol used to receive check box events.
 
-## [v1.0.0](https://github.com/Boris-Em/BEMCheckBox/tree/1.0.0) (2015-10-10)
-First stable release of **BEMCheckBox**
+As part of this release we had [2 issues](https://github.com/saturdaymp/BEMCheckBox/milestone/1?closed=1) closed.
+
+
+
+__Breaking__
+
+- [__#1__](https://github.com/saturdaymp/BEMCheckBox/pull/1) Update minimum iOS version from 8.4 to 12 and other Xcode project settings
+
+__DevOps__
+
+- [__#3__](https://github.com/saturdaymp/BEMCheckBox/pull/3) Create GitHub Action to build package for XPlugins.iOS.BEMCheckBox
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,13 @@ __DevOps__
 
 - [__#3__](https://github.com/saturdaymp/BEMCheckBox/pull/3) Create GitHub Action to build package for XPlugins.iOS.BEMCheckBox
 
+## 1.1.0 (Oct, 17, 2015)
+
+
+[Full Changelog](https://github.com/Boris-Em/BEMCheckBox/compare/1.0.0...1.1.0)
+ 
+Added new delegate and BEMCheckBoxDelegate protocol used to receive check box events.
+## 1.0.0 (Oct, 10, 2015)
+
+
+First stable release of **BEMCheckBox**

--- a/GitReleaseManager.yml
+++ b/GitReleaseManager.yml
@@ -1,0 +1,41 @@
+export:
+  include-created-date-in-title: true
+  created-date-string-format: MMM, d, yyyy
+
+issue-labels-include:
+  - breaking
+  - bug
+  - devops
+  - dependency
+  - documentation
+  - enhancement
+  - security
+
+issue-labels-alias:
+  - name: breaking
+    header: Breaking
+    plural: Breaking
+
+  - name: bug
+    header: Bug
+    plural: Bugs
+
+  - name: dependency
+    header: Dependency
+    plural: Dependencies
+
+  - name: devops
+    header: DevOps
+    plural: DevOps
+
+  - name: documentation
+    header: Documentation
+    plural: Documentation
+
+  - name: feature
+    header: Feature
+    plural: Feature
+
+  - name: security
+    header: Security
+    plural: Security

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,83 @@
+assembly-versioning-scheme: MajorMinorPatch
+assembly-file-versioning-scheme: MajorMinorPatch
+assembly-informational-format: '{InformationalVersion}'
+mode: ContinuousDelivery
+increment: Inherit
+continuous-delivery-fallback-tag: ci
+tag-prefix: '[vV]'
+major-version-bump-message: '\+semver:\s?(breaking|major)'
+minor-version-bump-message: '\+semver:\s?(feature|minor)'
+patch-version-bump-message: '\+semver:\s?(fix|patch)'
+no-bump-message: '\+semver:\s?(none|skip)'
+legacy-semver-padding: 4
+build-metadata-padding: 4
+commits-since-version-source-padding: 4
+tag-pre-release-weight: 60000
+commit-message-incrementing: Enabled
+ignore:
+  sha: [ ]
+merge-message-formats: {}
+update-build-number: true
+
+branches:
+  main:
+    regex: ^master$|^main$
+    mode: ContinuousDeployment
+    tag: alpha
+    increment: Minor
+    prevent-increment-of-merged-branch-version: false
+    track-merge-target: true
+    source-branches: [ ]
+    tracks-release-branches: true
+    is-release-branch: false
+    is-mainline: false
+    pre-release-weight: 0
+  release:
+    regex: ^releases?[/-]
+    mode: ContinuousDeployment
+    tag: beta
+    increment: Patch
+    prevent-increment-of-merged-branch-version: true
+    track-merge-target: false
+    source-branches: [ 'main' ]
+    tracks-release-branches: false
+    is-release-branch: true
+    is-mainline: false
+    pre-release-weight: 30000
+  feature:
+    regex: ^features?[/-]
+    mode: ContinuousDelivery
+    tag: useBranchName
+    increment: Inherit
+    prevent-increment-of-merged-branch-version: false
+    track-merge-target: false
+    source-branches: [ 'main', 'release' ]
+    tracks-release-branches: false
+    is-release-branch: false
+    is-mainline: false
+    pre-release-weight: 30000
+  pull-request:
+    regex: ^(pull|pull\-requests|pr)[/-]
+    mode: ContinuousDelivery
+    tag: PullRequest
+    increment: Inherit
+    prevent-increment-of-merged-branch-version: false
+    tag-number-pattern: '[/-](?<number>\d+)[-/]'
+    track-merge-target: false
+    source-branches: [ 'main', 'release', 'hotfix' ]
+    tracks-release-branches: false
+    is-release-branch: false
+    is-mainline: false
+    pre-release-weight: 30000
+  hotfix:
+    regex: ^hotfix(es)?[/-]
+    mode: ContinuousDelivery
+    tag: useBranchName
+    increment: Inherit
+    prevent-increment-of-merged-branch-version: false
+    track-merge-target: false
+    source-branches: [ 'release' ]
+    tracks-release-branches: false
+    is-release-branch: false
+    is-mainline: false
+    pre-release-weight: 30000

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,3 +1,4 @@
+next-version: 2.0.0
 assembly-versioning-scheme: MajorMinorPatch
 assembly-file-versioning-scheme: MajorMinorPatch
 assembly-informational-format: '{InformationalVersion}'

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Learn more about the **BEMCheckBox** project, licensing, support etc.
 <p align="center"><img src="./.assets/BEMCheckBox.gif"/></p>	
 
 ### Requirements
- - Requires iOS 7 or later. The sample project is optimized for iOS 9.
+ - Requires iOS 12 or later.
  - Requires Automatic Reference Counting (ARC).
  - Optimized for ARM64 Architecture.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # BEMCheckBox
-[![Build Status](https://travis-ci.org/Boris-Em/BEMCheckBox.svg)](https://travis-ci.org/Boris-Em/BEMCheckBox)
-[![Version](https://img.shields.io/cocoapods/v/BEMCheckBox.svg?style=flat)](http://cocoadocs.org/docsets/BEMCheckBox)
-[![License](https://img.shields.io/cocoapods/l/BEMCheckBox.svg?style=flat)](http://cocoadocs.org/docsets/BEMCheckBox)
-[![Platform](https://img.shields.io/cocoapods/p/BEMCheckBox.svg?style=flat)](http://cocoadocs.org/docsets/BEMCheckBox)
-[![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+[![CI](https://github.com/saturdaymp/BEMCheckBox/actions/workflows/ci.yml/badge.svg)](https://github.com/saturdaymp/BEMCheckBox/actions/workflows/ci.yml)
+[![Release Notes](https://github.com/saturdaymp/BEMCheckBox/actions/workflows/release-notes.yml/badge.svg)](https://github.com/saturdaymp/BEMCheckBox/actions/workflows/release-notes.yml)
 
 <p align="center"><img src="./.assets/BEMCheckBox logo.jpg"/></p>	
 


### PR DESCRIPTION
This PR adds a new workflow for generating release notes. The workflow is triggered on push or pull request events for the main and release branches. It runs on macOS and consists of several steps, including checking out the repository, installing GitVersion and GitReleaseManager, determining the version, creating a release using GitReleaseManager, generating a change log, and committing the change log if it has changed.