### PR TITLE
Fix unit test timeout issue in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,15 +34,18 @@ jobs:
           updateProjectFiles: true
 
       - name: Show SDKS
-        run: xcodebuild -showsdks
+        run: |
+          xcodebuild -showsdks
+          xcrun simctl list devices
 
       - name: Run Unit Tests
         run: |
           xcodebuild test \
             -project "Sample Project/CheckBox.xcodeproj" \
             -scheme CheckBoxTests \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -destination 'platform=iOS Simulator,OS=18.5,name=iPhone 16' \
             -resultBundlePath TestResults
+        timeout-minutes: 10
 
       # In XCode 12 it will build the simulator with a arm64 CPU.  We don't want this as when
       # we try to combine the simulator with the device build using Lipo we will get an error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v2.1.0 (Jan, 16, 2024)
 
 
-As part of this release we had [4 issues](https://github.com/saturdaymp/BEMCheckBox/milestone/2?closed=1) closed.
+As part of this release we had [5 issues](https://github.com/saturdaymp/BEMCheckBox/milestone/2?closed=1) closed.
 
 
 
@@ -13,6 +13,7 @@ __DevOps__
 
 - [__!12__](https://github.com/saturdaymp/BEMCheckBox/pull/12) Update macOS and GitHub Action Versions in CI
 - [__!13__](https://github.com/saturdaymp/BEMCheckBox/pull/13) Update GitVersion
+- [__!17__](https://github.com/saturdaymp/BEMCheckBox/pull/17) Fix release notes action error on main branch
 
 __enhancement__
 
@@ -54,11 +55,6 @@ This is the last official release from [Boris-Em](https://github.com/Boris-Em). 
 [Full Changelog](https://github.com/Boris-Em/BEMCheckBox/compare/1.0.0...1.1.0)
  
 Added new delegate and BEMCheckBoxDelegate protocol used to receive check box events.
-## 1.0.0 (Oct, 10, 2015)
-
-
-First stable release of **BEMCheckBox**
- to receive check box events.
 ## 1.0.0 (Oct, 10, 2015)
 
 


### PR DESCRIPTION
Adjust the unit test command to include a timeout and update the destination to specify the OS version for the iOS Simulator.