### PR TITLE
Prevent release notes generation on main branch push

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -6,7 +6,7 @@ permissions:
 
 on:
   push:
-    branches: [ main, release/* ]
+    branches: [ release/* ]
   pull_request:
     branches: [ main, release/* ]
 
@@ -57,4 +57,3 @@ jobs:
         with:
           commit_message: Committing auto generated change log.
           file_pattern: CHANGELOG.md
-          push_options: --force

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v2.1.0 (Jan, 16, 2024)
 
 
-As part of this release we had [5 issues](https://github.com/saturdaymp/BEMCheckBox/milestone/2?closed=1) closed.
+As part of this release we had [6 issues](https://github.com/saturdaymp/BEMCheckBox/milestone/2?closed=1) closed.
 
 
 
@@ -14,6 +14,7 @@ __DevOps__
 - [__!12__](https://github.com/saturdaymp/BEMCheckBox/pull/12) Update macOS and GitHub Action Versions in CI
 - [__!13__](https://github.com/saturdaymp/BEMCheckBox/pull/13) Update GitVersion
 - [__!17__](https://github.com/saturdaymp/BEMCheckBox/pull/17) Fix release notes action error on main branch
+- [__!19__](https://github.com/saturdaymp/BEMCheckBox/pull/19) Fix unit test timeout issue in GitHub Actions
 
 __enhancement__
 


### PR DESCRIPTION
Remove the automatic creation of release notes when pushing to the protected main branch. This change ensures that release notes are only generated for release branches.