### PR TITLE
Update CocaPods instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 ## v2.1.0 (Jan, 16, 2024)
 
 
-As part of this release we had [8 issues](https://github.com/saturdaymp/BEMCheckBox/milestone/2?closed=1) closed.
+As part of this release we had [9 issues](https://github.com/saturdaymp/BEMCheckBox/milestone/2?closed=1) closed.
 
+The user-facing changes in this release are:
 
+- Added accessibility features to the checkbox.  Please ping me if you they don't work and/or can be improved.
+- Updated the minimum iOS version from 12 to 18.
+
+Developer facing changes:
+
+- Updated from Swift 5 to 6 but use Swift 5 compatibility mode for now.
 
 __Breaking__
 
@@ -16,6 +23,7 @@ __DevOps__
 - [__!17__](https://github.com/saturdaymp/BEMCheckBox/pull/17) Fix release notes action error on main branch
 - [__!19__](https://github.com/saturdaymp/BEMCheckBox/pull/19) Fix unit test timeout issue in GitHub Actions
 - [__!20__](https://github.com/saturdaymp/BEMCheckBox/pull/20) Prevent release notes generation on main branch push
+- [__!22__](https://github.com/saturdaymp/BEMCheckBox/pull/22) Add 'refactoring' label to Git Release Manager config
 
 __enhancement__
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ It only takes a few simple steps to install and setup **BEMCheckBox** to your pr
 Add `https://github.com/saturdaymp/BEMCheckBox` as a dependency to your Package.swift file or select `File -> Swift Packages -> Add Package Dependency...` in Xcode.
 
 #### CocoaPods
-Note: The latest version on CocoaPods is [v1.4.1](https://cocoapods.org/pods/BEMCheckBox) by [Boris-Em](https://github.com/Boris-Em).  CocoaPods is being [deprecated](https://blog.cocoapods.org/CocoaPods-Specs-Repo/) so there is no plans to add new versions of BEMCheckBox to it.
+Note: The latest version on CocoaPods is [v1.4.1](https://cocoapods.org/pods/BEMCheckBox) by [Boris-Em](https://github.com/Boris-Em).  CocoaPods is being [deprecated](https://blog.cocoapods.org/CocoaPods-Specs-Repo/) so there are no plans to add new versions of BEMCheckBox to it.
 
 To install BEMCheckBox using CocoaPods add the following line to your `Podfile`:
 

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ It only takes a few simple steps to install and setup **BEMCheckBox** to your pr
 Add `https://github.com/saturdaymp/BEMCheckBox` as a dependency to your Package.swift file or select `File -> Swift Packages -> Add Package Dependency...` in Xcode.
 
 #### CocoaPods
-Note: The latest version on CocoaPods is [v1.4.1](https://cocoapods.org/pods/BEMCheckBox) by [Boris-Em](https://github.com/Boris-Em).  If you would like me to push a new version please open an [issue](https://github.com/saturdaymp/BEMCheckBox/issues) or [pull request](https://github.com/saturdaymp/BEMCheckBox/pulls).
+Note: The latest version on CocoaPods is [v1.4.1](https://cocoapods.org/pods/BEMCheckBox) by [Boris-Em](https://github.com/Boris-Em).  CocoaPods is being [deprecated](https://blog.cocoapods.org/CocoaPods-Specs-Repo/) so there is no plans to add new versions of BEMCheckBox to it.
 
-The easiest way to install **BEMCheckBox** is to use <a href="http://cocoapods.org/" target="_blank">CocoaPods</a>. To do so, simply add the following line to your `Podfile`:
+To install BEMCheckBox using CocoaPods add the following line to your `Podfile`:
+
 	<pre><code>pod 'BEMCheckBox'</code></pre>
-
 
 #### Carthage
 [Carthage](https://github.com/Carthage/Carthage) is a decentralized dependency manager that builds your dependencies and provides you with binary frameworks.


### PR DESCRIPTION
Update the CocaPod documentation with the note that no new pods will be published as CocoaPods is being deprecated.