### PR TITLE
Update CI permissions for artifact uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,7 @@
 name: CI
 
 permissions:
-  contents: read
-  pull-requests: write
+  contents: write          # Required to upload artifacts for tag builds
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 permissions:
-  contents: write          # Required to upload artifacts for tag builds
+  contents: write  # Required to upload artifacts for tag builds
 
 on:
   push:


### PR DESCRIPTION
Modify CI permissions to allow writing access, enabling artifact uploads for tag builds.